### PR TITLE
Fix compatibility with new version of TensorFlow 1.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 *.sh
 result/*
 !result/*.png
+venv

--- a/capsulelayers.py
+++ b/capsulelayers.py
@@ -7,12 +7,11 @@ uncommenting them and commenting their counterparts.
 Author: Xifeng Guo, E-mail: `guoxifeng1990@163.com`, Github: `https://github.com/XifengGuo/CapsNet-Keras`
 """
 
-import keras.backend as K
 import tensorflow as tf
-from keras import initializers, layers
+from tensorflow import keras
 
 
-class Length(layers.Layer):
+class Length(keras.layers.Layer):
     """
     Compute the length of vectors. This is used to compute a Tensor that has the same shape with y_true in margin_loss.
     Using this layer as model's output can directly predict labels by using `y_pred = np.argmax(model.predict(x), 1)`
@@ -20,9 +19,10 @@ class Length(layers.Layer):
     output: shape=[None, num_vectors]
     """
     def call(self, inputs, **kwargs):
-        return K.sqrt(K.sum(K.square(inputs), -1))
+        return tf.sqrt(tf.reduce_sum(tf.square(inputs), -1))
 
     def compute_output_shape(self, input_shape):
+        print('Lenght input_shape:', input_shape)
         return input_shape[:-1]
 
     def get_config(self):
@@ -30,7 +30,7 @@ class Length(layers.Layer):
         return config
 
 
-class Mask(layers.Layer):
+class Mask(keras.layers.Layer):
     """
     Mask a Tensor with shape=[None, num_capsule, dim_vector] either by the capsule with max length or by an additional 
     input mask. Except the max-length capsule (or specified capsule), all vectors are masked to zeros. Then flatten the
@@ -50,22 +50,23 @@ class Mask(layers.Layer):
             inputs, mask = inputs
         else:  # if no true label, mask by the max length of capsules. Mainly used for prediction
             # compute lengths of capsules
-            x = K.sqrt(K.sum(K.square(inputs), -1))
+            x = tf.sqrt(tf.reduce_sum(tf.square(inputs), -1))
             # generate the mask which is a one-hot code.
             # mask.shape=[None, n_classes]=[None, num_capsule]
-            mask = K.one_hot(indices=K.argmax(x, 1), num_classes=x.get_shape().as_list()[1])
+            mask = tf.one_hot(indices=tf.argmax(x, 1), depth=x.get_shape().as_list()[1])
 
         # inputs.shape=[None, num_capsule, dim_capsule]
         # mask.shape=[None, num_capsule]
         # masked.shape=[None, num_capsule * dim_capsule]
-        masked = K.batch_flatten(inputs * K.expand_dims(mask, -1))
+        masked = keras.backend.batch_flatten(inputs * tf.expand_dims(mask, -1))
         return masked
 
     def compute_output_shape(self, input_shape):
+        print('Mask input shape:', input_shape)
         if type(input_shape[0]) is tuple:  # true label provided
-            return tuple([None, input_shape[0][1] * input_shape[0][2]])
+            return tuple([None, int(input_shape[0][1]) * int(input_shape[0][2])])
         else:  # no true label provided
-            return tuple([None, input_shape[1] * input_shape[2]])
+            return tuple([None, int(input_shape[1]) * int(input_shape[2])])
 
     def get_config(self):
         config = super(Mask, self).get_config()
@@ -79,12 +80,12 @@ def squash(vectors, axis=-1):
     :param axis: the axis to squash
     :return: a Tensor with same shape as input vectors
     """
-    s_squared_norm = K.sum(K.square(vectors), axis, keepdims=True)
-    scale = s_squared_norm / (1 + s_squared_norm) / K.sqrt(s_squared_norm + K.epsilon())
+    s_squared_norm = tf.reduce_sum(tf.square(vectors), axis, keepdims=True)
+    scale = s_squared_norm / (1 + s_squared_norm) / tf.sqrt(s_squared_norm + keras.backend.epsilon())
     return scale * vectors
 
 
-class CapsuleLayer(layers.Layer):
+class CapsuleLayer(keras.layers.Layer):
     """
     The capsule layer. It is similar to Dense layer. Dense layer has `in_num` inputs, each is a scalar, the output of the 
     neuron from the former layer, and it has `out_num` output neurons. CapsuleLayer just expand the output of the neuron
@@ -102,12 +103,12 @@ class CapsuleLayer(layers.Layer):
         self.num_capsule = num_capsule
         self.dim_capsule = dim_capsule
         self.routings = routings
-        self.kernel_initializer = initializers.get(kernel_initializer)
+        self.kernel_initializer = keras.initializers.get(kernel_initializer)
 
     def build(self, input_shape):
         assert len(input_shape) >= 3, "The input Tensor should have shape=[None, input_num_capsule, input_dim_capsule]"
-        self.input_num_capsule = input_shape[1]
-        self.input_dim_capsule = input_shape[2]
+        self.input_num_capsule = int(input_shape[1])
+        self.input_dim_capsule = int(input_shape[2])
 
         # Transform matrix
         self.W = self.add_weight(shape=[self.num_capsule, self.input_num_capsule,
@@ -120,11 +121,11 @@ class CapsuleLayer(layers.Layer):
     def call(self, inputs, training=None):
         # inputs.shape=[None, input_num_capsule, input_dim_capsule]
         # inputs_expand.shape=[None, 1, input_num_capsule, input_dim_capsule]
-        inputs_expand = K.expand_dims(inputs, 1)
+        inputs_expand = tf.expand_dims(inputs, 1)
 
         # Replicate num_capsule dimension to prepare being multiplied by W
         # inputs_tiled.shape=[None, num_capsule, input_num_capsule, input_dim_capsule]
-        inputs_tiled = K.tile(inputs_expand, [1, self.num_capsule, 1, 1])
+        inputs_tiled = tf.tile(inputs_expand, [1, self.num_capsule, 1, 1])
 
         # Compute `inputs * W` by scanning inputs_tiled on dimension 0.
         # x.shape=[num_capsule, input_num_capsule, input_dim_capsule]
@@ -132,12 +133,12 @@ class CapsuleLayer(layers.Layer):
         # Regard the first two dimensions as `batch` dimension,
         # then matmul: [input_dim_capsule] x [dim_capsule, input_dim_capsule]^T -> [dim_capsule].
         # inputs_hat.shape = [None, num_capsule, input_num_capsule, dim_capsule]
-        inputs_hat = K.map_fn(lambda x: K.batch_dot(x, self.W, [2, 3]), elems=inputs_tiled)
+        inputs_hat = tf.map_fn(lambda x: keras.backend.batch_dot(x, self.W, [2, 3]), elems=inputs_tiled)
 
         # Begin: Routing algorithm ---------------------------------------------------------------------#
         # The prior for coupling coefficient, initialized as zeros.
         # b.shape = [None, self.num_capsule, self.input_num_capsule].
-        b = tf.zeros(shape=[K.shape(inputs_hat)[0], self.num_capsule, self.input_num_capsule])
+        b = tf.zeros(shape=[tf.shape(inputs_hat)[0], self.num_capsule, self.input_num_capsule])
 
         assert self.routings > 0, 'The routings should be > 0.'
         for i in range(self.routings):
@@ -149,7 +150,7 @@ class CapsuleLayer(layers.Layer):
             # The first two dimensions as `batch` dimension,
             # then matmal: [input_num_capsule] x [input_num_capsule, dim_capsule] -> [dim_capsule].
             # outputs.shape=[None, num_capsule, dim_capsule]
-            outputs = squash(K.batch_dot(c, inputs_hat, [2, 2]))  # [None, 10, 16]
+            outputs = squash(keras.backend.batch_dot(c, inputs_hat, [2, 2]))  # [None, 10, 16]
 
             if i < self.routings - 1:
                 # outputs.shape =  [None, num_capsule, dim_capsule]
@@ -157,7 +158,7 @@ class CapsuleLayer(layers.Layer):
                 # The first two dimensions as `batch` dimension,
                 # then matmal: [dim_capsule] x [input_num_capsule, dim_capsule]^T -> [input_num_capsule].
                 # b.shape=[batch_size, num_capsule, input_num_capsule]
-                b += K.batch_dot(outputs, inputs_hat, [2, 3])
+                b += keras.backend.batch_dot(outputs, inputs_hat, [2, 3])
         # End: Routing algorithm -----------------------------------------------------------------------#
 
         return outputs
@@ -183,10 +184,16 @@ def PrimaryCap(inputs, dim_capsule, n_channels, kernel_size, strides, padding):
     :param n_channels: the number of types of capsules
     :return: output tensor, shape=[None, num_capsule, dim_capsule]
     """
-    output = layers.Conv2D(filters=dim_capsule*n_channels, kernel_size=kernel_size, strides=strides, padding=padding,
-                           name='primarycap_conv2d')(inputs)
-    outputs = layers.Reshape(target_shape=[-1, dim_capsule], name='primarycap_reshape')(output)
-    return layers.Lambda(squash, name='primarycap_squash')(outputs)
+    output = keras.layers.Conv2D(filters=dim_capsule*n_channels, kernel_size=kernel_size, strides=strides, padding=padding,
+                                 name='primarycap_conv2d')(inputs)
+
+    # We need to calculate desired shape manually due to changed TF/Keras API
+    # keras.layers.Reshape now returns output shape [None, None, dim_capsule] instead [None, calculated_dim, dim_capsule]
+    conv_shape = output.get_shape()
+    desired_shape = [int(int(conv_shape[1]) * int(conv_shape[2]) * (int(conv_shape[3]) / dim_capsule)), dim_capsule]
+    outputs = keras.layers.Reshape(target_shape=desired_shape, name='primarycap_reshape')(output)
+    
+    return keras.layers.Lambda(squash, name='primarycap_squash')(outputs)
 
 
 """

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -17,15 +17,15 @@ Author: Xifeng Guo, E-mail: `guoxifeng1990@163.com`, Github: `https://github.com
 """
 
 import numpy as np
-from keras import layers, models, optimizers
-from keras import backend as K
-from keras.utils import to_categorical
 import matplotlib.pyplot as plt
-from utils import combine_images
+import tensorflow as tf
+from tensorflow import keras
 from PIL import Image
-from capsulelayers import CapsuleLayer, PrimaryCap, Length, Mask
 
-K.set_image_data_format('channels_last')
+from capsulelayers import CapsuleLayer, PrimaryCap, Length, Mask
+from utils import combine_images
+
+keras.backend.set_image_data_format('channels_last')
 
 
 def CapsNet(input_shape, n_class, routings):
@@ -37,10 +37,10 @@ def CapsNet(input_shape, n_class, routings):
     :return: Two Keras Models, the first one used for training, and the second one for evaluation.
             `eval_model` can also be used for training.
     """
-    x = layers.Input(shape=input_shape)
+    x = keras.layers.Input(shape=input_shape)
 
     # Layer 1: Just a conventional Conv2D layer
-    conv1 = layers.Conv2D(filters=256, kernel_size=9, strides=1, padding='valid', activation='relu', name='conv1')(x)
+    conv1 = keras.layers.Conv2D(filters=256, kernel_size=9, strides=1, padding='valid', activation='relu', name='conv1')(x)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to [None, num_capsule, dim_capsule]
     primarycaps = PrimaryCap(conv1, dim_capsule=8, n_channels=32, kernel_size=9, strides=2, padding='valid')
@@ -54,26 +54,26 @@ def CapsNet(input_shape, n_class, routings):
     out_caps = Length(name='capsnet')(digitcaps)
 
     # Decoder network.
-    y = layers.Input(shape=(n_class,))
+    y = keras.layers.Input(shape=(n_class,))
     masked_by_y = Mask()([digitcaps, y])  # The true label is used to mask the output of capsule layer. For training
     masked = Mask()(digitcaps)  # Mask using the capsule with maximal length. For prediction
 
     # Shared Decoder model in training and prediction
-    decoder = models.Sequential(name='decoder')
-    decoder.add(layers.Dense(512, activation='relu', input_dim=16*n_class))
-    decoder.add(layers.Dense(1024, activation='relu'))
-    decoder.add(layers.Dense(np.prod(input_shape), activation='sigmoid'))
-    decoder.add(layers.Reshape(target_shape=input_shape, name='out_recon'))
+    decoder = keras.models.Sequential(name='decoder')
+    decoder.add(keras.layers.Dense(512, activation='relu', input_dim=16*n_class))
+    decoder.add(keras.layers.Dense(1024, activation='relu'))
+    decoder.add(keras.layers.Dense(np.prod(input_shape), activation='sigmoid'))
+    decoder.add(keras.layers.Reshape(target_shape=input_shape, name='out_recon'))
 
     # Models for training and evaluation (prediction)
-    train_model = models.Model([x, y], [out_caps, decoder(masked_by_y)])
-    eval_model = models.Model(x, [out_caps, decoder(masked)])
+    train_model = keras.models.Model([x, y], [out_caps, decoder(masked_by_y)])
+    eval_model = keras.models.Model(x, [out_caps, decoder(masked)])
 
     # manipulate model
-    noise = layers.Input(shape=(n_class, 16))
-    noised_digitcaps = layers.Add()([digitcaps, noise])
+    noise = keras.layers.Input(shape=(n_class, 16))
+    noised_digitcaps = keras.layers.Add()([digitcaps, noise])
     masked_noised_y = Mask()([noised_digitcaps, y])
-    manipulate_model = models.Model([x, y, noise], decoder(masked_noised_y))
+    manipulate_model = keras.models.Model([x, y, noise], decoder(masked_noised_y))
     return train_model, eval_model, manipulate_model
 
 
@@ -84,10 +84,10 @@ def margin_loss(y_true, y_pred):
     :param y_pred: [None, num_capsule]
     :return: a scalar loss value.
     """
-    L = y_true * K.square(K.maximum(0., 0.9 - y_pred)) + \
-        0.5 * (1 - y_true) * K.square(K.maximum(0., y_pred - 0.1))
+    L = y_true * tf.square(tf.maximum(0., 0.9 - y_pred)) + \
+        0.5 * (1 - y_true) * tf.square(tf.maximum(0., y_pred - 0.1))
 
-    return K.mean(K.sum(L, 1))
+    return tf.reduce_mean(tf.reduce_sum(L, 1))
 
 
 def train(model, data, args):
@@ -102,15 +102,15 @@ def train(model, data, args):
     (x_train, y_train), (x_test, y_test) = data
 
     # callbacks
-    log = callbacks.CSVLogger(args.save_dir + '/log.csv')
-    tb = callbacks.TensorBoard(log_dir=args.save_dir + '/tensorboard-logs',
-                               batch_size=args.batch_size, histogram_freq=int(args.debug))
-    checkpoint = callbacks.ModelCheckpoint(args.save_dir + '/weights-{epoch:02d}.h5', monitor='val_capsnet_acc',
-                                           save_best_only=True, save_weights_only=True, verbose=1)
-    lr_decay = callbacks.LearningRateScheduler(schedule=lambda epoch: args.lr * (args.lr_decay ** epoch))
+    log = keras.callbacks.CSVLogger(args.save_dir + '/log.csv')
+    tb = keras.callbacks.TensorBoard(log_dir=args.save_dir + '/tensorboard-logs',
+                                     batch_size=args.batch_size, histogram_freq=int(args.debug))
+    checkpoint = keras.callbacks.ModelCheckpoint(args.save_dir + '/weights-{epoch:02d}.h5', monitor='val_capsnet_acc',
+                                                 save_best_only=True, save_weights_only=True, verbose=1)
+    lr_decay = keras.callbacks.LearningRateScheduler(schedule=lambda epoch: args.lr * (args.lr_decay ** epoch))
 
     # compile the model
-    model.compile(optimizer=optimizers.Adam(lr=args.lr),
+    model.compile(optimizer=keras.optimizers.Adam(lr=args.lr),
                   loss=[margin_loss, 'mse'],
                   loss_weights=[1., args.lam_recon],
                   metrics={'capsnet': 'accuracy'})
@@ -123,8 +123,8 @@ def train(model, data, args):
 
     # Begin: Training with data augmentation ---------------------------------------------------------------------#
     def train_generator(x, y, batch_size, shift_fraction=0.):
-        train_datagen = ImageDataGenerator(width_shift_range=shift_fraction,
-                                           height_shift_range=shift_fraction)  # shift up to 2 pixel for MNIST
+        train_datagen = keras.preprocessing.image.ImageDataGenerator(width_shift_range=shift_fraction,
+                                                                     height_shift_range=shift_fraction)  # shift up to 2 pixel for MNIST
         generator = train_datagen.flow(x, y, batch_size=batch_size)
         while 1:
             x_batch, y_batch = generator.next()
@@ -190,21 +190,18 @@ def manipulate_latent(model, data, args):
 
 def load_mnist():
     # the data, shuffled and split between train and test sets
-    from keras.datasets import mnist
-    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    (x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
 
     x_train = x_train.reshape(-1, 28, 28, 1).astype('float32') / 255.
     x_test = x_test.reshape(-1, 28, 28, 1).astype('float32') / 255.
-    y_train = to_categorical(y_train.astype('float32'))
-    y_test = to_categorical(y_test.astype('float32'))
+    y_train = keras.utils.to_categorical(y_train.astype('float32'))
+    y_test = keras.utils.to_categorical(y_test.astype('float32'))
     return (x_train, y_train), (x_test, y_test)
 
 
 if __name__ == "__main__":
     import os
     import argparse
-    from keras.preprocessing.image import ImageDataGenerator
-    from keras import callbacks
 
     # setting the hyper parameters
     parser = argparse.ArgumentParser(description="Capsule Network on MNIST.")


### PR DESCRIPTION
Now CapsNet can be used with TensorFlow 1.12! 💪

Some notes:
- Training converged on a small data subset, so I think I didn't break anything,
- Multi-GPU configuration needs investigation in future due to lack of hardware :(

Even if I run multi-GPU script with 0 or 1 GPU I get an error from Keras:
```
Traceback (most recent call last):
  File "capsulenet-multi-gpu.py", line 124, in <module>
    multi_model = keras.utils.multi_gpu_model(model, gpus=args.gpus)
  File "/Users/jakubpowierza/Documents/CapsNet-vs-CNN/venv/lib/python3.6/site-packages/tensorflow/python/keras/utils/multi_gpu_utils.py", line 167, in multi_gpu_model
    'Received: `gpus=%s`' % gpus)
ValueError: For multi-gpu usage to be effective, call `multi_gpu_model` with `gpus >= 2`. Received: `gpus=0`
```