### PR TITLE
License update

### DIFF
--- a/capsnet/LICENSE
+++ b/capsnet/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Jakub Powierza and Dawid Paluchowski
+Copyright (c) 2017 Xifeng Guo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Updated top level copyright owners. 

- Moved `CapsNet-Keras` license to the `capsnet` dir level.