### PR TITLE
Proper train & validation set and test dataset rotated by given angle

### DIFF
--- a/dataset/cifar10.py
+++ b/dataset/cifar10.py
@@ -5,9 +5,17 @@ import numpy as np
 
 
 IMAGE_SHAPE = (32, 32, 3)
-TRAIN_SIZE = 50000
+TRAIN_SIZE = 40000
+VALIDATION_SIZE = 10000
 TEST_SIZE = 10000
 CLASSES = 10
+RANDOM_ROTATION_CONFIG = {
+    'rotation_range': 30,  # Random rotations from -30 deg to 30 deg
+    'width_shift_range': 0.1,
+    'height_shift_range': 0.1,
+    'horizontal_flip': True,
+    'vertical_flip': False,  # Doesn't make sense in CIFAR10
+}
 
 
 @functools.lru_cache()
@@ -20,20 +28,16 @@ def _load_data():
     y_train = keras.utils.to_categorical(y_train.astype('float32'))
     y_test = keras.utils.to_categorical(y_test.astype('float32'))
 
-    return (x_train, y_train), (x_test, y_test)
+    x_train, x_validation = x_train[:TRAIN_SIZE], x_train[TRAIN_SIZE:]
+    y_train, y_validation = y_train[:TRAIN_SIZE], y_train[TRAIN_SIZE:]
+
+    return (x_train, y_train), (x_validation, y_validation), (x_test, y_test)
 
 
 def get_train_generator_for_cnn(batch_size):
-    (x_train, y_train), (_, _) = _load_data()
+    (x_train, y_train), (_, _), (_, _) = _load_data()
 
-    config = {
-        'rotation_range': 30,  # Random rotations from -30 deg to 30 deg
-        'width_shift_range': 0.1,
-        'height_shift_range': 0.1,
-        'horizontal_flip': True,
-        'vertical_flip': False,  # Doesn't make sense in CIFAR10
-    }
-    train_datagen = keras.preprocessing.image.ImageDataGenerator(**config)
+    train_datagen = keras.preprocessing.image.ImageDataGenerator(**RANDOM_ROTATION_CONFIG)
     generator = train_datagen.flow(x_train, y_train, batch_size=batch_size)
 
     while 1:
@@ -47,16 +51,28 @@ def get_train_generator_for_capsnet(batch_size):
 
 
 def get_validation_data_for_cnn():
-    (_, _), (x_test, y_test) = _load_data()
-    return [x_test, y_test]
+    (_, _), (x_validation, y_validation), (_, _) = _load_data()
+
+    train_datagen = keras.preprocessing.image.ImageDataGenerator(**RANDOM_ROTATION_CONFIG)
+    generator = train_datagen.flow(x_validation, y_validation, batch_size=1)
+
+    x_validation = np.empty_like(x_validation)
+    y_validation = np.empty_like(y_validation)
+    for i, (x_batch, y_batch) in enumerate(generator):
+        if i >= VALIDATION_SIZE:
+            break
+        x_validation[i:(i+1)] = x_batch[:]
+        y_validation[i:(i+1)] = y_batch[:]
+    return [x_validation, y_validation]
 
 
 def get_validation_data_for_capsnet():
-    x_test, y_test = get_validation_data_for_cnn()
-    return [[x_test, y_test], [y_test, x_test]]
+    x_validation, y_validation = get_validation_data_for_cnn()
+    return [[x_validation, y_validation], [y_validation, x_validation]]
 
 
-def get_test_data():
-    (_, _), (x_test, y_test) = _load_data()
+def get_test_data(rotation=0.0):
+    (_, _), (_, _), (x_test, y_test) = _load_data()
+    x_test = np.array([keras.preprocessing.image.apply_affine_transform(image, theta=rotation) for image in x_test])
     return (x_test, y_test)
 


### PR DESCRIPTION
Changes:
- split training dataset into training and validation (80/20),
- validation set will be randomly rotated,
- test set may be rotated by given angle (0 by default).

**NOTE:** This code needs a refactoring due to duplicated logic... I've created a task for that on our kanban board.