### PR TITLE
Move CapsNet to CIFAR10 dataset & Evaluation script for CNN/CapsNet networks

### DIFF
--- a/capsnet/capsulenet.py
+++ b/capsnet/capsulenet.py
@@ -47,7 +47,7 @@ def CapsNet(input_shape, n_class, routings):
     conv1 = keras.layers.Conv2D(filters=256, kernel_size=9, strides=1, padding='valid', activation='relu', name='conv1')(x)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to [None, num_capsule, dim_capsule]
-    primarycaps = PrimaryCap(conv1, dim_capsule=8, n_channels=32, kernel_size=9, strides=2, padding='valid')
+    primarycaps = PrimaryCap(conv1, dim_capsule=16, n_channels=64, kernel_size=9, strides=2, padding='valid')
 
     # Layer 3: Capsule layer. Routing algorithm works here.
     digitcaps = CapsuleLayer(num_capsule=n_class, dim_capsule=16, routings=routings,
@@ -180,7 +180,7 @@ if __name__ == "__main__":
                         help="Initial learning rate")
     parser.add_argument('--lr_decay', default=0.9, type=float,
                         help="The value multiplied by lr at each epoch. Set a larger value for larger epochs")
-    parser.add_argument('--lam_recon', default=0.392, type=float,
+    parser.add_argument('--lam_recon', default=1.563, type=float,
                         help="The coefficient for the loss of decoder")
     parser.add_argument('-r', '--routings', default=3, type=int,
                         help="Number of iterations used in routing algorithm. should > 0")

--- a/capsnet/capsulenet.py
+++ b/capsnet/capsulenet.py
@@ -25,7 +25,7 @@ import tensorflow as tf
 from tensorflow import keras
 from PIL import Image
 
-from dataset import mnist
+from dataset import cifar10
 from capsnet.capsulelayers import CapsuleLayer, PrimaryCap, Length, Mask
 from capsnet.utils import combine_images, plot_log
 
@@ -34,7 +34,7 @@ keras.backend.set_image_data_format('channels_last')
 
 def CapsNet(input_shape, n_class, routings):
     """
-    A Capsule Network on MNIST.
+    A Capsule Network on CIFAR.
     :param input_shape: data shape, 3d, [width, height, channels]
     :param n_class: number of classes
     :param routings: number of routing iterations
@@ -116,10 +116,10 @@ def train(model, args):
                   metrics={'capsnet': 'accuracy'})
 
     # Training
-    model.fit_generator(generator=mnist.get_train_generator_for_capsnet(args.batch_size),
-                        steps_per_epoch=int(mnist.TRAIN_SIZE / args.batch_size),
+    model.fit_generator(generator=cifar10.get_train_generator_for_capsnet(args.batch_size),
+                        steps_per_epoch=int(cifar10.TRAIN_SIZE / args.batch_size),
                         epochs=args.epochs,
-                        validation_data=mnist.get_validation_data_for_capsnet(),
+                        validation_data=cifar10.get_validation_data_for_capsnet(),
                         callbacks=[log, tb, checkpoint, lr_decay])
 
     model.save_weights(args.save_dir + '/trained_model.h5')
@@ -131,7 +131,7 @@ def train(model, args):
 
 
 def test(model, args):
-    x_test, y_test = mnist.get_test_data()
+    x_test, y_test = cifar10.get_test_data()
     y_pred, x_recon = model.predict(x_test, batch_size=100)
     print('-'*30 + 'Begin: test' + '-'*30)
     print('Test acc:', np.sum(np.argmax(y_pred, 1) == np.argmax(y_test, 1))/y_test.shape[0])
@@ -148,7 +148,7 @@ def test(model, args):
 
 def manipulate_latent(model, args):
     print('-'*30 + 'Begin: manipulate' + '-'*30)
-    x_test, y_test = mnist.get_test_data()
+    x_test, y_test = cifar10.get_test_data()
     index = np.argmax(y_test, 1) == args.digit
     number = np.random.randint(low=0, high=sum(index) - 1)
     x, y = x_test[index][number], y_test[index][number]
@@ -200,8 +200,8 @@ if __name__ == "__main__":
         os.makedirs(args.save_dir)
 
     # define model
-    model, eval_model, manipulate_model = CapsNet(input_shape=mnist.IMAGE_SHAPE,
-                                                  n_class=mnist.CLASSES,
+    model, eval_model, manipulate_model = CapsNet(input_shape=cifar10.IMAGE_SHAPE,
+                                                  n_class=cifar10.CLASSES,
                                                   routings=args.routings)
     model.summary()
 

--- a/cnn/resnet.py
+++ b/cnn/resnet.py
@@ -248,7 +248,7 @@ model.fit_generator(cifar10.get_train_generator_for_cnn(batch_size),
                     callbacks=callbacks)
 
 # Score trained model.
-x_test, y_test = cifar10.get_test_data()
+x_test, y_test = cifar10.get_test_data_for_cnn()
 scores = model.evaluate(x_test, y_test, verbose=1)
 print('Test loss:', scores[0])
 print('Test accuracy:', scores[1])

--- a/dataset/cifar10.py
+++ b/dataset/cifar10.py
@@ -71,8 +71,13 @@ def get_validation_data_for_capsnet():
     return [[x_validation, y_validation], [y_validation, x_validation]]
 
 
-def get_test_data(rotation=0.0):
+def get_test_data_for_cnn(rotation=0.0):
     (_, _), (_, _), (x_test, y_test) = _load_data()
     x_test = np.array([keras.preprocessing.image.apply_affine_transform(image, theta=rotation) for image in x_test])
     return (x_test, y_test)
+
+
+def get_test_data_for_capsnet(rotation=0.0):
+    x_test, y_test = get_test_data_for_cnn(rotation)
+    return [[x_test, y_test], [y_test, x_test]]
 

--- a/dataset/mnist.py
+++ b/dataset/mnist.py
@@ -71,8 +71,13 @@ def get_validation_data_for_capsnet():
     return [[x_validation, y_validation], [y_validation, x_validation]]
 
 
-def get_test_data(rotation=0.0):
+def get_test_data_for_cnn(rotation=0.0):
     (_, _), (_, _), (x_test, y_test) = _load_data()
     x_test = np.array([keras.preprocessing.image.apply_affine_transform(image, theta=rotation) for image in x_test])
     return (x_test, y_test)
+
+
+def get_test_data_for_capsnet(rotation=0.0):
+    x_test, y_test = get_test_data_for_cnn()
+    return [[x_test, y_test], [y_test, x_test]]
 

--- a/evaluation/test.py
+++ b/evaluation/test.py
@@ -10,30 +10,31 @@ import argparse
 import numpy as np
 
 from dataset import cifar10
+from cnn.resnet import resnet_v2
 from capsnet.capsulenet import CapsNet
 
 CAPSNET_ROUTINGS = 3  # TODO: Allow to override it!
 
 
-def load_model(network_type, weights):
+def evaluate(network_type, weights):
     if network_type == 'capsnet':
         model, eval_model, _ = CapsNet(input_shape=cifar10.IMAGE_SHAPE, n_class=cifar10.CLASSES, routings=CAPSNET_ROUTINGS)
-        model.summary()
-        model.load_weights(weights)
-        return model
     elif network_type == 'cnn':
-        print('Will be done later...')
+        model = resnet_v2(input_shape=cifar10.IMAGE_SHAPE, depth=12*9+2)
 
+    model.summary()
+    model.load_weights(weights)
 
-def evaluate(model):
-    if not model:
-        print('Model was not loaded...')
-        exit(0)
-    
     for rotation in [-45, -30, -15, 0, 15, 30, 45]:
-        x_test, y_test = cifar10.get_test_data_for_capsnet(rotation)
-        y_pred, x_reconstructed = model.predict(x_test, batch_size=100)
-        accuracy = np.sum(np.argmax(y_pred, 1) == np.argmax(y_test[0], 1))/y_test[0].shape[0]
+        if network_type == 'capsnet':
+            x_test, y_test = cifar10.get_test_data_for_capsnet(rotation)
+            y_pred, x_reconstructed = model.predict(x_test, batch_size=100)
+            accuracy = np.sum(np.argmax(y_pred, 1) == np.argmax(y_test[0], 1))/y_test[0].shape[0]
+        elif network_type == 'cnn':
+            x_test, y_test = cifar10.get_test_data_for_cnn(rotation)
+            scores = model.evaluate(x_test, y_test, verbose=1)
+            accuracy = scores[1]
+
         print('Rotation:', rotation, 'Accuracy:', accuracy)
 
 
@@ -43,6 +44,5 @@ if __name__ == '__main__':
     parser.add_argument('--weights', required=True, type=str)
     args = parser.parse_args()
 
-    model = load_model(args.network_type, args.weights)
-    evaluate(model)
+    evaluate(args.network_type, args.weights)
 

--- a/evaluation/test.py
+++ b/evaluation/test.py
@@ -1,0 +1,43 @@
+import argparse
+
+import numpy as np
+
+from dataset import cifar10
+from capsnet.capsulenet import CapsNet
+
+CAPSNET_ROUTINGS = 3  # TODO: Allow to override it!
+
+
+def load_model(network_type, weights):
+    if network_type == 'capsnet':
+        model, eval_model, _ = CapsNet(input_shape=cifar10.IMAGE_SHAPE,
+                                       n_class=cifar10.CLASSES,
+                                       routings=CAPSNET_ROUTINGS)
+        model.summary()
+        model.load_weights(weights)
+        return model
+    elif network_type == 'cnn':
+        print('Will be done later...')
+
+
+def evaluate(model):
+    if not model:
+        print('Model was not loaded...')
+        exit(0)
+    
+    for rotation in [-45, -30, -15, 0, 15, 30, 45]:
+        x_test, y_test = cifar10.get_test_data_for_capsnet(rotation)
+        y_pred, x_reconstructed = model.predict(x_test, batch_size=100)
+        accuracy = np.sum(np.argmax(y_pred, 1) == np.argmax(y_test[0], 1))/y_test[0].shape[0]
+        print('Rotation:', rotation, 'Accuracy:', accuracy)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Capsule Network on MNIST.")
+    parser.add_argument('--network-type', required=True, type=str)
+    parser.add_argument('--weights', required=True, type=str)
+    args = parser.parse_args()
+
+    model = load_model(args.network_type, args.weights)
+    evaluate(model)
+

--- a/evaluation/test.py
+++ b/evaluation/test.py
@@ -39,7 +39,7 @@ def evaluate(network_type, weights):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Capsule Network on MNIST.")
+    parser = argparse.ArgumentParser(description='Evaluation of CNN and CapsNet networks against rotated images.')
     parser.add_argument('--network-type', required=True, type=str)
     parser.add_argument('--weights', required=True, type=str)
     args = parser.parse_args()

--- a/evaluation/test.py
+++ b/evaluation/test.py
@@ -1,3 +1,10 @@
+"""Evaluation script for both CapsNet and CNN models.
+
+Example use:
+
+    $ python evaluation/test.py --network-type=capsnet --weights=./result/weights-01.h5
+
+"""
 import argparse
 
 import numpy as np
@@ -10,9 +17,7 @@ CAPSNET_ROUTINGS = 3  # TODO: Allow to override it!
 
 def load_model(network_type, weights):
     if network_type == 'capsnet':
-        model, eval_model, _ = CapsNet(input_shape=cifar10.IMAGE_SHAPE,
-                                       n_class=cifar10.CLASSES,
-                                       routings=CAPSNET_ROUTINGS)
+        model, eval_model, _ = CapsNet(input_shape=cifar10.IMAGE_SHAPE, n_class=cifar10.CLASSES, routings=CAPSNET_ROUTINGS)
         model.summary()
         model.load_weights(weights)
         return model


### PR DESCRIPTION
**New things:**
- CIFAR10 dataset in CapsNet,
- Evaluation script for CNNs and CapsNets,
- Extend arguments for CapsNet training:

```bash
$ python capsnet/capsulenet.py --primary_capsules=32 --number_of_primary_channels=16 --digit_capsules=16
```

**Side note:**
For now, the best model was found using this command (52%):

```bash
$ python capsnet/capsulenet.py --primary_capsules=32 --number_of_primary_channels=32 --digit_capsules=16 --save_dir=./result_32_32_16 --epochs=100
```

Other training parameters were default.